### PR TITLE
Use python2

### DIFF
--- a/plugin/wakatime.vim
+++ b/plugin/wakatime.vim
@@ -84,7 +84,7 @@ let s:VERSION = '0.2.2'
             let targetFile = a:last[2]
         endif
         if targetFile != ''
-            let cmd = ['python', s:plugin_directory . 'packages/wakatime/wakatime.py']
+            let cmd = ['python2', s:plugin_directory . 'packages/wakatime/wakatime.py']
             let cmd = cmd + ['--file', shellescape(targetFile)]
             let cmd = cmd + ['--time', printf('%f', a:time)]
             let cmd = cmd + ['--plugin', printf('vim-wakatime/%s', s:VERSION)]


### PR DESCRIPTION
The plugin doesn't work with python3 so the command should call python2 for those users who have python symlinked to python3.
