### PR TITLE
Fixed string errors for unexpected repo formats

### DIFF
--- a/plugin/packages/wakatime/wakatime/projects/git.py
+++ b/plugin/packages/wakatime/wakatime/projects/git.py
@@ -43,7 +43,11 @@ class Git(BaseProject):
             sections = self._parse_config()
             for section in sections:
                 if section.split(' ', 1)[0] == 'remote' and 'url' in sections[section]:
-                    remote = sections[section]['url'].rsplit(':', 1)[1].rsplit('/', 1)[1].split('.git', 1)[0]
+                    remote = sections[section]['url'].rsplit(':', 1)[1]
+                    try:
+                        remote = remote.rsplit('/' , 1)[1].split('.git' , 1)[0]
+                    except:
+                        pass
                     tags.append(remote)
             branch = self._current_branch()
             if branch is not None:


### PR DESCRIPTION
Was getting exceptions thrown because I have remotes that have the following URL format:

user@host:repo.com

This fixes that.

I don't really write Python, but this was the best way I could explain what was going wrong and how to fix it, so I apologise if this isn't the way to go about it!
