### PR TITLE
BUGFIX: Shell fails to execute cli.py if plugin_directory contains spaces

### DIFF
--- a/plugin/wakatime.vim
+++ b/plugin/wakatime.vim
@@ -114,7 +114,7 @@ let s:VERSION = '4.0.0'
                     let python_bin = 'pythonw'
                 endif
             endif
-            let cmd = [python_bin, '-W', 'ignore', s:plugin_directory . 'packages/wakatime/cli.py']
+            let cmd = [python_bin, '-W', 'ignore', '"' . s:plugin_directory . 'packages/wakatime/cli.py"']
             let cmd = cmd + ['--file', shellescape(targetFile)]
             let cmd = cmd + ['--plugin', shellescape(printf('vim/%d vim-wakatime/%s', v:version, s:VERSION))]
             if a:is_write


### PR DESCRIPTION
There is an issue where if the `s:plugin_directory` variable contains any spaces the shell will interpret the file name of the `cli.py` script in chunks.

e.g. if the path is '/home/my files/' the shell sees: `python /home/my files/cli.py` which obviously gets mangled.

Escaping the cli.py path with `"`s fies this issue.