### PR TITLE
Adding back go language detection

### DIFF
--- a/plugin/packages/wakatime/languages/vim.json
+++ b/plugin/packages/wakatime/languages/vim.json
@@ -168,6 +168,7 @@
   "gitsendemail": null,
   "gkrellmrc": null,
   "gnuplot": null,
+  "go": "Go",
   "gp": null,
   "gpg": null,
   "grads": null,


### PR DESCRIPTION
Not sure when this happened, but noticed that my go projects were being classified as 'Other' language in the dashboard. This should address that. 