### PR TITLE
Adding installation instructions for Vim-plug plugin manager in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Installation
 
    Or with [Pathogen](https://github.com/tpope/vim-pathogen): `cd ~/.vim/bundle && git clone git://github.com/wakatime/vim-wakatime.git`
 
-   Or with [Vim-plug](https://github.com/junegunn/vim-plug):  add `Plug 'wakatime/vim-wakatime` to .vimrc file, reload .vimrc with `:so ~/.vimrc`, 
-    `:PlugInstall` to install.
+   Or with [Vim-plug](https://github.com/junegunn/vim-plug):  add `Plug 'wakatime/vim-wakatime` to .vimrc file. While in vim reload .vimrc with `:so ~/.vimrc` or restart vim, enter
+    `:PlugInstall`.
 
 2. Enter your [api key](https://wakatime.com/settings#apikey), then press `enter`. 
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Installation
    Or with [Vim-plug](https://github.com/junegunn/vim-plug):  add `Plug 'wakatime/vim-wakatime` to /.vimrc file, reload .vimrc with `:so ~/.vimrc`, 
    `:PlugInstall` to install.
 
-2. Enter your [api key](https://wakatime.com/settings#apikey), then press `enter`.
+2. Enter your [api key](https://wakatime.com/settings#apikey), then press `enter`. _(does not apply to vim-plug)_
 
 3. Use Vim and your coding activity will be displayed on your [WakaTime dashboard](https://wakatime.com).
 
@@ -87,6 +87,7 @@ Uninstalling
 3. Run in terminal: `vim +PluginClean`.
 
 _If using vim-plug_
+
 **While in vim**
 
 1. Delete or comment out `Plug` command

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ Installation
 
    Or with [Pathogen](https://github.com/tpope/vim-pathogen): `cd ~/.vim/bundle && git clone git://github.com/wakatime/vim-wakatime.git`
 
-   Or with [Vim-plug](https://github.com/junegunn/vim-plug):  add `Plug 'wakatime/vim-wakatime` to /.vimrc file, reload .vimrc with `:so ~/.vimrc`, 
+   Or with [Vim-plug](https://github.com/junegunn/vim-plug):  add `Plug 'wakatime/vim-wakatime` to .vimrc file, reload .vimrc with `:so ~/.vimrc`, 
    `:PlugInstall` to install.
 
-2. Enter your [api key](https://wakatime.com/settings#apikey), then press `enter`. _(does not apply to vim-plug)_
+2. Enter your [api key](https://wakatime.com/settings#apikey), then press `enter`. 
 
 3. Use Vim and your coding activity will be displayed on your [WakaTime dashboard](https://wakatime.com).
 
@@ -90,7 +90,7 @@ _If using vim-plug_
 
 **While in vim**
 
-1. Delete or comment out `Plug` command
+1. Delete or comment out `Plug` command from .vimrc file.
 
 2. Reload vimrc (`:so ~/.vimrc`) or restart vim
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ Installation
 
    Or with [Pathogen](https://github.com/tpope/vim-pathogen): `cd ~/.vim/bundle && git clone git://github.com/wakatime/vim-wakatime.git`
 
+   Or with [Vim-plug](https://github.com/junegunn/vim-plug):  add `Plug 'wakatime/vim-wakatime` to /.vimrc file, reload .vimrc with `:so ~/.vimrc`, 
+   `:PlugInstall` to install.
+
 2. Enter your [api key](https://wakatime.com/settings#apikey), then press `enter`.
 
 3. Use Vim and your coding activity will be displayed on your [WakaTime dashboard](https://wakatime.com).
@@ -83,6 +86,14 @@ Uninstalling
 
 3. Run in terminal: `vim +PluginClean`.
 
+_If using vim-plug_
+**While in vim**
+
+1. Delete or comment out `Plug` command
+
+2. Reload vimrc (`:so ~/.vimrc`) or restart vim
+
+3. Run `:PlugClean`, it will detect and remove undeclared plugins.
 
 [wakatime-cli]: https://github.com/wakatime/wakatime
 [wakatime-cli-config]: https://github.com/wakatime/wakatime#configuring

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Installation
    Or with [Pathogen](https://github.com/tpope/vim-pathogen): `cd ~/.vim/bundle && git clone git://github.com/wakatime/vim-wakatime.git`
 
    Or with [Vim-plug](https://github.com/junegunn/vim-plug):  add `Plug 'wakatime/vim-wakatime` to .vimrc file, reload .vimrc with `:so ~/.vimrc`, 
-   `:PlugInstall` to install.
+    `:PlugInstall` to install.
 
 2. Enter your [api key](https://wakatime.com/settings#apikey), then press `enter`. 
 


### PR DESCRIPTION
A bit back I was looking to see if Wakatime would work for my Vim plugin manager. Installed with the way I've detailed in this updated readme. It's been a while and everything is still solid in Wakatime for me, so I'd love for you to check out this updated readme with support for the [vim-plugin](https://github.com/junegunn/vim-plug) manager. Feel free to work with the formatting. 