### PR TITLE
Fix async in vim8

### DIFF
--- a/plugin/wakatime.vim
+++ b/plugin/wakatime.vim
@@ -55,7 +55,7 @@ let s:VERSION = '8.0.1'
     let s:heartbeats_buffer = []
     let s:send_buffer_seconds = 30  " seconds between sending buffered heartbeats
     let s:last_sent = localtime()
-    let s:has_async = has('patch-7.4-2344') && exists('*job_start')
+    let s:has_async = exists('*job_start')
     let s:nvim_async = exists('*jobstart')
 
 


### PR DESCRIPTION
I'm not sure why this patch check is included, but at least on my system with
vim 8.2 it causes the async to actually _not_ run, slowing down things whenever
I write my files.

Signed-off-by: Wolfgang E. Sanyer <WolfgangESanyer@gmail.com>
