### PR TITLE
impr: Add python/dyn support

### DIFF
--- a/plugin/wakatime.vim
+++ b/plugin/wakatime.vim
@@ -192,9 +192,9 @@ let s:VERSION = '9.0.1'
                     let stdout = system(s:JoinArgs(cmd) . ' &')
                 endif
             endif
-        elseif s:Executable(v:progname) && (has('python3') || has('python'))
+        elseif s:Executable(v:progname) && (has('python3') || has('python') || has('python3_dynamic') || has('python_dynamic'))
             call s:InstallCLIRoundAbout()
-        elseif has('python3')
+        elseif has('python3') || has('python3_dynamic')
             python3 << EOF
 import sys
 import vim
@@ -203,7 +203,7 @@ sys.path.insert(0, abspath(join(vim.eval('s:plugin_root_folder'), 'scripts')))
 from install_cli import main
 main(home=vim.eval('s:home'))
 EOF
-        elseif has('python')
+        elseif has('python') || has('python_dynamic')
             python << EOF
 import sys
 import vim
@@ -219,7 +219,7 @@ EOF
     endfunction
 
     function! s:InstallCLIRoundAbout()
-        if has('python3')
+        if has('python3') || has('python3_dynamic')
             let py = 'python3'
         else
             let py = 'python'


### PR DESCRIPTION
This pull request adds support for `python/dyn`, which is used instead of `python` on some systems by default, such as Arch.

For example, running the following command on my system shows I only have `python3/dyn`, and not `python` or `python3`.

```
❯ vim --version | grep -E "^(\+|-)[a-zA-Z]" | sed "s/ +/\n+/g" | sed "s/ -/\n-/g" | tr -d ' ' | grep python
-python
+python3/dyn
```

Without this, the plugin will think I don't have python support on my vim install:
```
❯ vim --cmd "echo has('python')" -c "q!"
0

❯ vim --cmd "echo has('python3_dynamic')" -c "q!"
1
```