### PR TITLE
feat: support install for android

### DIFF
--- a/scripts/install_cli.py
+++ b/scripts/install_cli.py
@@ -27,10 +27,12 @@ except ImportError:
 
 
 def getOsName():
-    os = platform.system().lower()
-    if os.startswith('cygwin') or os.startswith('mingw') or os.startswith('msys'):
+    osName = platform.system().lower()
+    if osName.startswith('cygwin') or osName.startswith('mingw') or osName.startswith('msys'):
         return 'windows'
-    return os
+    if platform.system() == 'Linux' and 'ANDROID_DATA' in os.environ:
+        return 'android'
+    return osName
 
 
 GITHUB_RELEASES_STABLE_URL = 'https://api.github.com/repos/wakatime/wakatime-cli/releases/latest'
@@ -360,6 +362,8 @@ def cliDownloadUrl():
     arch = architecture()
 
     validCombinations = [
+      'android-arm',
+      'android-arm64',
       'darwin-amd64',
       'darwin-arm64',
       'freebsd-386',


### PR DESCRIPTION
resolve: #167 
![Screenshot_20231009_122423_Termux](https://github.com/wakatime/vim-wakatime/assets/30729921/80e3fcb1-52d7-41e5-a115-cca0062f2bc6)

Why `os` variabel I change to `osName`, because it get conflict to `os.envrion` from `import os`