### PR TITLE
Add installation instructions for vim 8+

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,17 @@
 
 1. With [Vundle](https://github.com/gmarik/vundle): `echo "Plugin 'wakatime/vim-wakatime'" >> ~/.vimrc && vim +PluginInstall`
 
-   Or with [Pathogen](https://github.com/tpope/vim-pathogen): `cd ~/.vim/bundle && git clone git://github.com/wakatime/vim-wakatime.git`
+   Or with [Pathogen](https://github.com/tpope/vim-pathogen): `cd ~/.vim/bundle && git clone https://github.com/wakatime/vim-wakatime.git`
 
    Or with [Vim-plug](https://github.com/junegunn/vim-plug):  add `Plug 'wakatime/vim-wakatime'` to .vimrc file. While in vim reload .vimrc with `:so ~/.vimrc` or restart vim, enter
     `:PlugInstall`
 
-   Or with [Packer](https://github.com/wbthomason/packer.nvim): add `use 'wakatime/vim-wakatime'` to your plugins file.
+   Or with [Packer](https://github.com/wbthomason/packer.nvim): add `use 'wakatime/vim-wakatime'` to your plugins file.  
+   Or with [Vim 8+](https://www.vim.org/): `mkdir -p ~/.vim/pack/plugins/start && ~/.vim/pack/plugins/start && git clone https://github.com/wakatime/vim-wakatime.git`
 
-2. Enter your [api key](https://wakatime.com/settings#apikey), then press `enter`.
+   Then start `vim`. You should be prompted to enter your WakaTime [API Key](https://wakatime.com/settings#apikey).
+
+2. Enter your [API Key](https://wakatime.com/settings#apikey), then press `enter`.
 
 3. Use Vim and your coding activity will be displayed on your [WakaTime dashboard](https://wakatime.com).
 


### PR DESCRIPTION
Vim 8+ supports installing plugins using the Vim's plugin manager. By creating .vim/pack/<plugin-directory>/start directory and cloning the plugin directory there. It will be loaded at startup no need to load it automatic or to add any configuration in the .vimrc configuration file.