### PR TITLE
Respect user-provided `cli_path` in autoupdate logic

### DIFF
--- a/lua/wakatime/init.lua
+++ b/lua/wakatime/init.lua
@@ -446,17 +446,19 @@ setup_cli = function()
         state.autoupdate_cli = false
         if state.is_debug_on then vim.notify('[WakaTime] Using Homebrew wakatime-cli', vim.log.levels.DEBUG) end
       else
-        -- Default to ~/.wakatime location and enable auto-update
+        -- Default to ~/.wakatime location and enable auto-update ONLY if no user cli_path was given
         state.wakatime_cli = default_path
-        state.autoupdate_cli = true
+        state.autoupdate_cli = (state.config.cli_path == nil)
         if state.is_debug_on then
           vim.notify(
-            fmt('[WakaTime] Using default CLI path: %s (autoupdate enabled)', state.wakatime_cli),
+            fmt('[WakaTime] Using default CLI path: %s (autoupdate %s)', state.wakatime_cli, state.autoupdate_cli and 'enabled' or 'disabled'),
             vim.log.levels.DEBUG
           )
         end
-        -- Try installing/updating if using the default path
-        install_cli()
+        -- Try installing/updating if using the default path and autoupdate is enabled
+        if state.autoupdate_cli and not executable(state.wakatime_cli) then
+          install_cli()
+        end
       end
     end
 

--- a/plugin/wakatime.vim
+++ b/plugin/wakatime.vim
@@ -103,11 +103,11 @@ let s:VERSION = '12.0.0'
         let s:autoupdate_cli = s:false
 
         " Check vimrc config for wakatime-cli binary path
-        if exists("g:wakatime_CLIPath") && filereadable(g:wakatime_CLIPath)
+        if exists("g:wakatime_CLIPath")
             let s:wakatime_cli = g:wakatime_CLIPath
 
         " Legacy configuration of wakatime-cli
-        elseif exists("g:wakatime_OverrideCommandPrefix") && filereadable(g:wakatime_OverrideCommandPrefix)
+        elseif exists("g:wakatime_OverrideCommandPrefix")
             let s:wakatime_cli = g:wakatime_OverrideCommandPrefix
 
         " Check $PATH and ~/.wakatime/wakatime-cli symlink
@@ -126,7 +126,7 @@ let s:VERSION = '12.0.0'
             elseif !filereadable(path) && filereadable('/usr/local/bin/wakatime-cli')
                 let s:wakatime_cli = '/usr/local/bin/wakatime-cli'
 
-            " Default to ~/.wakatime/wakatime-cli
+            " Default to ~/.wakatime/wakatime-cli and enable auto-update
             else
                 let s:autoupdate_cli = s:true
                 let s:wakatime_cli = path
@@ -139,7 +139,7 @@ let s:VERSION = '12.0.0'
     endfunction
 
     function! s:InstallCLI(use_external_python)
-        if !s:autoupdate_cli && s:Executable(s:wakatime_cli)
+        if !s:autoupdate_cli || s:Executable(s:wakatime_cli)
             return
         endif
 
@@ -359,7 +359,9 @@ EOF
     function! s:SetupCLI()
         if !s:cli_already_setup
             let s:cli_already_setup = s:true
-            call s:InstallCLI(s:true)
+            if s:autoupdate_cli && !s:Executable(s:wakatime_cli)
+                call s:InstallCLI(s:true)
+            endif
         endif
     endfunction
 


### PR DESCRIPTION
Hello o/

I've recently picked vim-wakatime back up after the Lua rewrite, but noticed that the plugin tells the user to download the wakatime-cli to `~/.wakatime` even when the CLI path is set. This PR makes it so that the warning is not shown when the CLI path is set, assuming the use knows what they're doing. My motivation is that on NixOS systems or Neovim configurations managed by Nix, it's common practice for `cli_path` to be set unconditionally to a Nix store path, and downloading imperatively is considered bad practice.

Change-Id: I4926f80e595892b88c2b3f781c8164e16a6a6964