### PR TITLE
Allow configuring status_bar_enabled from lazyvim config

### DIFF
--- a/lua/wakatime/init.lua
+++ b/lua/wakatime/init.lua
@@ -1224,11 +1224,13 @@ function M.setup(user_config)
       state.config.redraw_setting = vi_redraw
     end
   end
-  local status_bar_enabled = get_ini_setting('settings', 'status_bar_enabled')
-  if status_bar_enabled == 'false' then
-    state.config.status_bar_enabled = false
-  elseif status_bar_enabled == 'true' then
-    state.config.status_bar_enabled = true
+  if user_config.status_bar_enabled == nil then
+    local status_bar_enabled = get_ini_setting('settings', 'status_bar_enabled')
+    if status_bar_enabled == 'false' then
+      state.config.status_bar_enabled = false
+    elseif status_bar_enabled == 'true' then
+      state.config.status_bar_enabled = true
+    end
   end
   -- Apply debug from config file (will be re-checked in setup_debug_mode)
   local debug_setting = get_ini_setting('settings', 'debug')

--- a/lua/wakatime/init.lua
+++ b/lua/wakatime/init.lua
@@ -1188,13 +1188,17 @@ end
 -- Setup Function (Main entry point)
 
 function M.setup(user_config)
+  user_config = user_config or {}
+
   if state.initialized then
-    vim.notify('[WakaTime] Already initialized.', vim.log.levels.WARN)
+    -- Re-apply opts when called again (e.g. user setup runs after auto-init from plugin/wakatime.vim)
+    if next(user_config) ~= nil then
+      state.config = vim.tbl_deep_extend('force', state.config, user_config)
+    end
     return
   end
 
   -- Merge user config with defaults
-  user_config = user_config or {}
   state.config = vim.tbl_deep_extend('force', state.config, user_config)
 
   -- Determine home directory

--- a/lua/wakatime/init.lua
+++ b/lua/wakatime/init.lua
@@ -1194,7 +1194,8 @@ function M.setup(user_config)
   end
 
   -- Merge user config with defaults
-  state.config = vim.tbl_deep_extend('force', state.config, user_config or {})
+  user_config = user_config or {}
+  state.config = vim.tbl_deep_extend('force', state.config, user_config)
 
   -- Determine home directory
   local wakatime_home_env = os.getenv('WAKATIME_HOME')

--- a/lua/wakatime/init.lua
+++ b/lua/wakatime/init.lua
@@ -1218,9 +1218,11 @@ function M.setup(user_config)
   state.shared_state_file = state.shared_state_parent_dir .. '/vim_shared_state'
 
   -- Apply settings from config file if they exist (e.g., vi_redraw)
-  local vi_redraw = get_ini_setting('settings', 'vi_redraw')
-  if vi_redraw == 'enabled' or vi_redraw == 'auto' or vi_redraw == 'disabled' then
-    state.config.redraw_setting = vi_redraw
+  if user_config.redraw_setting == nil then
+    local vi_redraw = get_ini_setting('settings', 'vi_redraw')
+    if vi_redraw == 'enabled' or vi_redraw == 'auto' or vi_redraw == 'disabled' then
+      state.config.redraw_setting = vi_redraw
+    end
   end
   local status_bar_enabled = get_ini_setting('settings', 'status_bar_enabled')
   if status_bar_enabled == 'false' then


### PR DESCRIPTION
## Summary

I was working on my projects when I noticed a time in my statusline, and I knew that was something related to Wakatime. I tried to disabe it from my Lazy config by doing this:
```lua
    {
        "wakatime/vim-wakatime",
        lazy = false,
        opts = {
            status_bar_enabled = false,
        },
    },
```

But it wasn't working. I had to spend some time trying to figure out what was going on and I realized that you can, indeed, disable this from the configuration file in `~/.wakatime.cfg`. But the problem is, **_I should be able to configure this from neovim_**.

## Changes

1. Precedence fix — Settings in `~/.wakatime.cfg` no longer override values explicitly passed by the caller. `status_bar_enabled` and `redraw_setting` are now only pulled from the config file when the caller hasn't specified them.
2. Re-call fix — `M.setup()` no longer bails out early if it's already been initialized. Instead, it re-merges any non-empty `user_config` into the current state. This was needed because `plugin/wakatime.vim` automatically calls `setup()` with no options on load — before lazy.nvim gets a chance to run its own config block.
3. Refactor — `user_config` is now normalized to an empty table upfront (`user_config = user_config or {}`), so the rest of the code can reliably check which keys the caller actually provided.

Precedence is now user opts (neovim) > ~/.wakatime.cfg > defaults, regardless of plugin load order.

## Tests

Test case: Config present in user opts (neovim) and not present in `~/.wakatime.cfg`
Result: config loaded from neovim 

Test case: Config **not** present in user opts (neovim) and not present in `~/.wakatime.cfg`
Result: config loaded from config file

Test case: Config present in user opts (neovim) and value set to **true** and present in `~/.wakatime.cfg` and value set to **false**
Result: neovim config takes priority